### PR TITLE
Better control of display size, limited by jupyter restrictions

### DIFF
--- a/R/34_Segmentation_Evaluation.ipynb
+++ b/R/34_Segmentation_Evaluation.ipynb
@@ -52,10 +52,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
    "outputs": [],
    "source": [
+    "## save the default options in case you need to reset them\n",
+    "if (!exists(\"default.options\")) \n",
+    "{\n",
+    "default.options <- options()\n",
+    "}\n",
     "# display 2D images inside the notebook (colour and greyscale)\n",
     "show_inline <- function(object, Dwidth=grid::unit(5, \"cm\"))\n",
     "{\n",
@@ -78,6 +83,14 @@
     "  worlddim <- worlddim / worlddim[1]\n",
     "  W <- Dwidth\n",
     "  H <- Dwidth * worlddim[2]\n",
+    "  WW <- grid::convertX(W*1.1, \"inches\", valueOnly=TRUE)\n",
+    "  HH <- grid::convertY(H*1.1, \"inches\", valueOnly=TRUE)\n",
+    "  ## here we set the display size\n",
+    "  ## Jupyter only honours the last setting for a cell, so\n",
+    "  ## we can't reset the original options. That needs to\n",
+    "  ## be done manually, using the \"default.options\" stored above\n",
+    "  ## Obvious point to do this is before plotting graphs\n",
+    "  options(repr.plot.width = WW, repr.plot.height = HH)\n",
     "  grid::grid.raster(A, default.units=\"mm\", width=W, height=H)\n",
     "}\n",
     "\n",
@@ -93,7 +106,7 @@
     "    tiled_image <- Paste(tiled_image, images[[i]], images[[i]]$GetSize(), c(0, 0), c((i - 1) * width, 0))\n",
     "  }\n",
     "  return( tiled_image )\n",
-    "}"
+    "}\n"
    ]
   },
   {
@@ -134,7 +147,7 @@
     "                           function(seg) LabelMapContourOverlay(Cast(seg[,,slice_for_display], \"sitkLabelUInt8\"), \n",
     "                                                                display_slice,\n",
     "                                                                opacity = 1))\n",
-    "    \n",
+    "   \n",
     "show_inline(color_tile(display_overlays),grid::unit(15, \"cm\"))"
    ]
   },
@@ -303,6 +316,8 @@
    "source": [
     "library(tidyr)\n",
     "library(ggplot2)\n",
+    "## reset the plot size\n",
+    "options(default.options)\n",
     "overlap.gathered <- gather(overlap_measures, key=Measure, value=Score, -rater)\n",
     "ggplot(overlap.gathered,\n",
     "       aes(x=rater, y=abs(Score), group=Measure, fill=Measure)) +\n",
@@ -350,7 +365,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "3.2.3"
+   "version": "3.3.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Turns out there are some special option flags that Jupyter uses. There are some issues as only one setting is allowed per cell, with the last one being honoured. This means it isn't possible to automatically reset to the previous setting. This isn't an issue if only images are being displayed, but it is a hassle when there is a mix of images and other plots. My solution is to save the options at the beginning so there is a copy that can be used to reset plot options.

Also, there may be a bug in the image concatenate function -  assumes images are the same width, but perhaps that is the idea